### PR TITLE
Support multi repo

### DIFF
--- a/lib/mongo.ex
+++ b/lib/mongo.ex
@@ -144,7 +144,7 @@ defmodule Mongo do
     child_opts
     |> Map.new()
     |> Map.merge(%{
-      id: __MODULE__,
+      id: child_opts[:id] || __MODULE__,
       start: {__MODULE__, :start_link, [opts]}
     })
   end


### PR DESCRIPTION
Based on the issue https://github.com/elixir-mongo/mongodb/issues/366.

The original mongo repo https://github.com/elixir-mongo/mongodb is not actively maintained right now, so this repo is forked. `tubi` is the default branch, which include's @csWen's `use-crypto-mac` branch.